### PR TITLE
Fix ship purchasing to only buy cargo-capable vessels

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -18,6 +18,9 @@ from models.state_enums import AgentState
 from utils.logging import setup_logging
 from states.base_state import BaseState
 from states.assess_situation import AssessSituationState
+from states.negotiate_contract import NegotiateContractState
+from states.accept_contract import AcceptContractState
+from states.acquire_resources import AcquireResourcesState
 
 
 class SpaceTradersAgent:
@@ -383,6 +386,9 @@ class SpaceTradersAgent:
     def _register_states(self) -> None:
         """Register implemented state classes."""
         self.state_registry[AgentState.ASSESS_SITUATION] = AssessSituationState(self.context)
+        self.state_registry[AgentState.NEGOTIATE_CONTRACT] = NegotiateContractState(self.context)
+        self.state_registry[AgentState.ACCEPT_CONTRACT] = AcceptContractState(self.context)
+        self.state_registry[AgentState.ACQUIRE_RESOURCES] = AcquireResourcesState(self.context)
     
     def register_state(self, state_enum: AgentState, state_class: BaseState) -> None:
         """Register a state implementation."""

--- a/api/client.py
+++ b/api/client.py
@@ -185,6 +185,11 @@ class SpaceTradersAPIClient:
         data = {"symbol": trade_symbol, "units": units}
         return self._make_request("POST", f"/v2/my/ships/{ship_symbol}/sell", json=data)
     
+    def purchase_ship(self, ship_type: str, waypoint_symbol: str) -> Dict[str, Any]:
+        """Purchase a ship at a shipyard."""
+        data = {"shipType": ship_type, "waypointSymbol": waypoint_symbol}
+        return self._make_request("POST", "/v2/my/ships", json=data)
+    
     # System and waypoint endpoints
     
     def get_system(self, system_symbol: str) -> Dict[str, Any]:

--- a/prompt_history/step4.md
+++ b/prompt_history/step4.md
@@ -1,0 +1,4 @@
+# Step 4 Prompt
+
+step4:
+now you can implement NEGOTIATE_CONTRACT and ACCEPT_CONTRACT

--- a/states/accept_contract.py
+++ b/states/accept_contract.py
@@ -1,0 +1,173 @@
+"""
+ACCEPT_CONTRACT state implementation.
+
+This state accepts a previously selected contract and prepares for execution.
+"""
+
+from typing import Optional
+from models.state_enums import AgentState
+from states.base_state import BaseState
+
+
+class AcceptContractState(BaseState):
+    """
+    State for accepting a selected contract.
+    
+    This state:
+    1. Accepts the contract that was selected in NEGOTIATE_CONTRACT
+    2. Updates the contract status in the context
+    3. Records acceptance metrics
+    4. Prepares for contract execution
+    """
+    
+    def execute(self) -> Optional[AgentState]:
+        """
+        Execute the ACCEPT_CONTRACT state logic.
+        
+        Returns:
+            AgentState: Next state to transition to (PLAN_FULFILLMENT, NEGOTIATE_CONTRACT, or ERROR_RECOVERY)
+        """
+        self.log_state_entry()
+        
+        try:
+            # Verify we have a contract to accept
+            if not self.context.current_contract:
+                self.logger.warning("No contract selected for acceptance - returning to negotiation")
+                return AgentState.NEGOTIATE_CONTRACT
+            
+            contract = self.context.current_contract
+            
+            # Check if contract is already accepted
+            if contract.accepted:
+                self.logger.info(f"Contract {contract.contract_id} already accepted - proceeding to fulfillment")
+                next_state = AgentState.PLAN_FULFILLMENT
+                self.log_state_exit(next_state)
+                return next_state
+            
+            # Attempt to accept the contract
+            success = self._accept_contract(contract)
+            
+            if success:
+                self.logger.info(f"Successfully accepted contract {contract.contract_id}")
+                
+                # Update contract status
+                contract.accepted = True
+                
+                # Record metrics
+                self._record_contract_acceptance()
+                
+                # Log acceptance details
+                self._log_acceptance_details(contract)
+                
+                next_state = AgentState.PLAN_FULFILLMENT
+                self.log_state_exit(next_state)
+                return next_state
+                
+            else:
+                self.logger.warning(f"Failed to accept contract {contract.contract_id} - returning to negotiation")
+                # Clear the failed contract
+                self.context.current_contract = None
+                return AgentState.NEGOTIATE_CONTRACT
+                
+        except Exception as e:
+            self.logger.error(f"Error in ACCEPT_CONTRACT state: {e}")
+            return AgentState.ERROR_RECOVERY
+    
+    def _accept_contract(self, contract) -> bool:
+        """
+        Accept the contract via the API.
+        
+        Args:
+            contract: Contract to accept
+            
+        Returns:
+            bool: True if acceptance successful, False otherwise
+        """
+        self.logger.info(f"Attempting to accept contract {contract.contract_id}...")
+        
+        try:
+            response = self.api_client.accept_contract(contract.contract_id)
+            
+            if response and 'data' in response:
+                contract_data = response['data']['contract']
+                agent_data = response['data']['agent']
+                
+                # Update contract with latest data
+                if contract_data:
+                    contract.accepted = contract_data.get('accepted', False)
+                    contract.fulfilled = contract_data.get('fulfilled', False)
+                
+                # Update agent credits from the acceptance payment
+                if agent_data:
+                    old_credits = self.context.agent_data.credits if self.context.agent_data else 0
+                    new_credits = agent_data.get('credits', 0)
+                    credits_gained = new_credits - old_credits
+                    
+                    if credits_gained > 0:
+                        self.logger.info(f"Received {credits_gained:,} credits for contract acceptance")
+                    
+                    # Update agent data
+                    self.context.update_agent_data({'data': agent_data})
+                
+                return contract.accepted
+            else:
+                self.logger.error("Invalid response format from contract acceptance API")
+                return False
+                
+        except Exception as e:
+            self.logger.error(f"Failed to accept contract {contract.contract_id}: {e}")
+            return False
+    
+    def _record_contract_acceptance(self) -> None:
+        """Record metrics for contract acceptance."""
+        # This could be expanded to track more detailed metrics
+        self.logger.debug("Recording contract acceptance metrics")
+        
+        # Update strategy based on acceptance
+        if self.context.current_contract:
+            contract_type = self.context.current_contract.contract_type.value
+            payment = self.context.current_contract.terms.total_payment
+            
+            # Simple strategy adjustment - could be more sophisticated
+            if contract_type not in self.context.strategy_config.get('successful_contract_types', []):
+                successful_types = self.context.strategy_config.get('successful_contract_types', [])
+                successful_types.append(contract_type)
+                self.context.strategy_config['successful_contract_types'] = successful_types
+    
+    def _log_acceptance_details(self, contract) -> None:
+        """Log details about the accepted contract."""
+        self.logger.info("=== CONTRACT ACCEPTED ===")
+        self.logger.info(f"Contract ID: {contract.contract_id}")
+        self.logger.info(f"Type: {contract.contract_type.value}")
+        self.logger.info(f"Faction: {contract.faction_symbol}")
+        self.logger.info(f"Total Payment: {contract.terms.total_payment:,} credits")
+        self.logger.info(f"Payment on Accept: {contract.terms.payment_on_accepted:,} credits")
+        self.logger.info(f"Payment on Fulfill: {contract.terms.payment_on_fulfilled:,} credits")
+        
+        # Log deliveries
+        self.logger.info("Required Deliveries:")
+        for i, delivery in enumerate(contract.terms.deliveries, 1):
+            self.logger.info(f"  {i}. {delivery.units_required} {delivery.trade_symbol} "
+                           f"to {delivery.destination_symbol}")
+        
+        # Log deadline
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc)
+        time_remaining = contract.terms.deadline - now
+        hours_remaining = time_remaining.total_seconds() / 3600
+        days_remaining = hours_remaining / 24
+        
+        self.logger.info(f"Deadline: {contract.terms.deadline}")
+        if days_remaining >= 1:
+            self.logger.info(f"Time remaining: {days_remaining:.1f} days")
+        else:
+            self.logger.info(f"Time remaining: {hours_remaining:.1f} hours")
+        
+        # Log current resources
+        if self.context.agent_data:
+            self.logger.info(f"Current Credits: {self.context.agent_data.credits:,}")
+        
+        total_cargo = self.context.get_total_cargo_capacity()
+        available_cargo = self.context.get_available_cargo_space()
+        self.logger.info(f"Cargo Capacity: {available_cargo}/{total_cargo} available")
+        self.logger.info("=========================")

--- a/states/acquire_resources.py
+++ b/states/acquire_resources.py
@@ -1,0 +1,455 @@
+"""
+ACQUIRE_RESOURCES state implementation.
+
+This state handles purchasing ships and upgrading existing ones to meet contract requirements.
+"""
+
+from typing import Optional, List, Dict, Any
+from models.state_enums import AgentState
+from states.base_state import BaseState
+from models.ship import Ship
+
+
+class AcquireResourcesState(BaseState):
+    """
+    State for acquiring additional resources (ships, upgrades, fuel) to meet contract requirements.
+    
+    This state:
+    1. Analyzes current resource gaps
+    2. Finds available shipyards
+    3. Evaluates and purchases suitable ships
+    4. Ensures ships are fueled and ready
+    """
+    
+    def execute(self) -> Optional[AgentState]:
+        """
+        Execute the ACQUIRE_RESOURCES state logic.
+        
+        Returns:
+            AgentState: Next state to transition to
+        """
+        self.log_state_entry()
+        
+        try:
+            # Step 1: Analyze what resources we need
+            resource_needs = self._analyze_resource_needs()
+            
+            if not resource_needs['need_resources']:
+                self.logger.info("No additional resources needed - proceeding to contract execution")
+                next_state = AgentState.NEGOTIATE_CONTRACT
+                self.log_state_exit(next_state)
+                return next_state
+            
+            # Step 2: Find available shipyards
+            shipyards = self._find_shipyards()
+            
+            if not shipyards:
+                self.logger.warning("No shipyards found in current system - cannot acquire ships")
+                self.logger.info("Agent will wait for contracts that fit current capacity or explore other systems")
+                
+                # Mark that we tried to acquire resources but failed
+                # This prevents immediate retrying
+                import time
+                self.context.strategy_config['last_acquire_attempt'] = time.time()
+                self.context.strategy_config['acquire_failed'] = True
+                
+                # Fall back to trying contracts with current capacity, but wait longer
+                time.sleep(60)  # Wait 1 minute before trying again
+                next_state = AgentState.NEGOTIATE_CONTRACT
+                self.log_state_exit(next_state)
+                return next_state
+            
+            # Check if any shipyards have ships available
+            shipyards_with_ships = [sy for sy in shipyards if len(sy['shipyard_data'].get('ships', [])) > 0]
+            if not shipyards_with_ships:
+                self.logger.warning("Found shipyards but none have ships in stock - cannot acquire ships")
+                self.logger.info("Shipyard inventories refresh periodically - will wait and try again")
+                
+                # Mark that we tried to acquire resources but failed
+                import time
+                self.context.strategy_config['last_acquire_attempt'] = time.time()
+                self.context.strategy_config['acquire_failed'] = True
+                
+                # Wait longer since shipyards need time to restock
+                time.sleep(300)  # Wait 5 minutes before trying again
+                next_state = AgentState.NEGOTIATE_CONTRACT
+                self.log_state_exit(next_state)
+                return next_state
+            
+            self.logger.info(f"Found {len(shipyards_with_ships)} shipyards with ships in stock out of {len(shipyards)} total")
+            
+            # Step 3: Purchase ships if needed
+            if resource_needs['need_cargo_capacity']:
+                success = self._purchase_cargo_ship(shipyards_with_ships, resource_needs['min_cargo_needed'])
+                
+                if not success:
+                    self.logger.warning("Failed to purchase suitable cargo ship")
+                    # Try again later or with different strategy
+                    import time
+                    time.sleep(30)
+                    next_state = AgentState.NEGOTIATE_CONTRACT
+                    self.log_state_exit(next_state)
+                    return next_state
+            
+            # Step 4: Refuel ships if needed
+            self._ensure_ships_fueled()
+            
+            # Step 5: Update ship data
+            self._refresh_ship_data()
+            
+            self.logger.info("Successfully acquired additional resources")
+            next_state = AgentState.NEGOTIATE_CONTRACT
+            self.log_state_exit(next_state)
+            return next_state
+            
+        except Exception as e:
+            self.logger.error(f"Error in ACQUIRE_RESOURCES state: {e}")
+            return AgentState.ERROR_RECOVERY
+    
+    def _analyze_resource_needs(self) -> Dict[str, Any]:
+        """
+        Analyze what resources the agent currently needs.
+        
+        Returns:
+            Dict with analysis of resource needs
+        """
+        self.logger.info("Analyzing resource needs...")
+        
+        current_capacity = self.context.get_total_cargo_capacity()
+        ships_needing_fuel = [ship for ship in self.context.ships if ship.fuel.needs_refuel]
+        
+        # Simple heuristic: if we're in this state, we probably need more cargo capacity
+        # In a real implementation, this could be more sophisticated
+        target_capacity = max(60, current_capacity + 20)  # At least 60 units or 20 more than current
+        
+        needs = {
+            'need_resources': False,
+            'need_cargo_capacity': False,
+            'need_fuel': len(ships_needing_fuel) > 0,
+            'min_cargo_needed': 0,
+            'current_capacity': current_capacity,
+            'target_capacity': target_capacity,
+            'ships_needing_fuel': ships_needing_fuel
+        }
+        
+        if current_capacity < target_capacity:
+            needs['need_resources'] = True
+            needs['need_cargo_capacity'] = True
+            needs['min_cargo_needed'] = target_capacity - current_capacity
+        
+        if ships_needing_fuel:
+            needs['need_resources'] = True
+        
+        self.logger.info(f"Resource analysis: Current capacity: {current_capacity}, "
+                        f"Target: {target_capacity}, Need fuel: {len(ships_needing_fuel)} ships")
+        
+        return needs
+    
+    def _find_shipyards(self) -> List[Dict[str, Any]]:
+        """
+        Find shipyards where we can purchase ships.
+        
+        Returns:
+            List of shipyard information
+        """
+        self.logger.info("Finding available shipyards...")
+        
+        shipyards = []
+        
+        try:
+            # Start with headquarters system
+            if self.context.agent_data:
+                headquarters = self.context.agent_data.headquarters
+                system_symbol = self.api_client.extract_system_from_waypoint(headquarters)
+                
+                self.logger.info(f"Searching for shipyards in system {system_symbol} (HQ: {headquarters})")
+                
+                # Get ALL waypoints in the headquarters system (with pagination)
+                all_waypoints = []
+                page = 1
+                limit = 20
+                
+                while True:
+                    response = self.api_client.get_system_waypoints(system_symbol, page=page, limit=limit)
+                    waypoints = response.get('data', [])
+                    
+                    if not waypoints:
+                        break
+                    
+                    all_waypoints.extend(waypoints)
+                    self.logger.debug(f"Page {page}: Got {len(waypoints)} waypoints")
+                    
+                    # Check if there are more pages
+                    meta = response.get('meta', {})
+                    total_pages = meta.get('total', 0) // limit + (1 if meta.get('total', 0) % limit > 0 else 0)
+                    
+                    if page >= total_pages or len(waypoints) < limit:
+                        break
+                    
+                    page += 1
+                
+                self.logger.info(f"Found {len(all_waypoints)} total waypoints in system {system_symbol} across {page} pages")
+                
+                # Find waypoints with shipyards
+                for waypoint in all_waypoints:
+                    waypoint_symbol = waypoint.get('symbol')
+                    traits = waypoint.get('traits', [])
+                    trait_symbols = [trait.get('symbol') for trait in traits]
+                    
+                    self.logger.info(f"Waypoint {waypoint_symbol} has traits: {trait_symbols}")
+                    
+                    has_shipyard = any(trait.get('symbol') == 'SHIPYARD' for trait in traits)
+                    
+                    if has_shipyard:
+                        self.logger.info(f"Found shipyard at {waypoint_symbol}")
+                        
+                        try:
+                            # Get shipyard details
+                            shipyard_response = self.api_client.get_shipyard(system_symbol, waypoint_symbol)
+                            shipyard_data = shipyard_response.get('data', {})
+                            
+                            ships_available = len(shipyard_data.get('ships', []))
+                            self.logger.info(f"Shipyard at {waypoint_symbol} has {ships_available} ships available")
+                            
+                            # Log details of available ships
+                            ships = shipyard_data.get('ships', [])
+                            for ship_info in ships:
+                                ship_type = ship_info.get('type', 'UNKNOWN')
+                                price = ship_info.get('purchasePrice', 0)
+                                cargo_info = ship_info.get('cargo', {})
+                                cargo_capacity = cargo_info.get('capacity', 0)
+                                
+                                self.logger.info(f"  - {ship_type}: {price:,} credits, {cargo_capacity} cargo capacity")
+                            
+                            shipyards.append({
+                                'waypoint_symbol': waypoint_symbol,
+                                'system_symbol': system_symbol,
+                                'shipyard_data': shipyard_data
+                            })
+                            
+                        except Exception as e:
+                            self.logger.warning(f"Failed to get shipyard details for {waypoint_symbol}: {e}")
+                            continue
+            
+            self.logger.info(f"Found {len(shipyards)} accessible shipyards")
+            return shipyards
+            
+        except Exception as e:
+            self.logger.error(f"Failed to find shipyards: {e}")
+            return []
+    
+    def _purchase_cargo_ship(self, shipyards: List[Dict[str, Any]], min_cargo_needed: int) -> bool:
+        """
+        Purchase a ship with good cargo capacity.
+        
+        Args:
+            shipyards: List of available shipyards
+            min_cargo_needed: Minimum additional cargo capacity needed
+            
+        Returns:
+            bool: True if purchase successful
+        """
+        self.logger.info(f"Looking for cargo ship with at least {min_cargo_needed} additional capacity...")
+        
+        if not self.context.agent_data:
+            self.logger.error("No agent data available for ship purchase")
+            return False
+        
+        available_credits = self.context.agent_data.credits
+        safety_reserve = self.context.strategy_config.get('safety_credit_reserve', 10000)
+        purchasable_credits = available_credits - safety_reserve
+        
+        self.logger.info(f"Available credits for ship purchase: {purchasable_credits:,}")
+        
+        best_ship = None
+        best_shipyard = None
+        best_value = 0  # Cargo capacity per credit
+        
+        for shipyard in shipyards:
+            shipyard_data = shipyard['shipyard_data']
+            ships = shipyard_data.get('ships', [])
+            
+            for ship_info in ships:
+                ship_type = ship_info.get('type')
+                price = ship_info.get('purchasePrice', 0)
+                
+                if price > purchasable_credits:
+                    self.logger.debug(f"Ship {ship_type} costs {price:,}, exceeds budget")
+                    continue
+                
+                # Get actual cargo capacity from ship's cargo specification
+                cargo_info = ship_info.get('cargo', {})
+                cargo_capacity = cargo_info.get('capacity', 0)
+                
+                self.logger.debug(f"Ship {ship_type} has {cargo_capacity} cargo capacity (from cargo spec)")
+                
+                # Skip ships with no cargo capacity (like surveyors)
+                if cargo_capacity <= 0:
+                    self.logger.debug(f"Ship {ship_type} has no cargo capacity - skipping")
+                    continue
+                
+                if cargo_capacity < min_cargo_needed:
+                    self.logger.debug(f"Ship {ship_type} has {cargo_capacity} cargo, need at least {min_cargo_needed}")
+                    continue
+                
+                # Calculate value (cargo per credit)
+                value = cargo_capacity / max(price, 1)
+                
+                self.logger.info(f"Ship option: {ship_type} - {cargo_capacity} cargo, {price:,} credits, value: {value:.6f}")
+                
+                if value > best_value:
+                    best_ship = ship_info
+                    best_shipyard = shipyard
+                    best_value = value
+        
+        if not best_ship:
+            self.logger.warning("No suitable ships found within budget")
+            return False
+        
+        # Purchase the best ship
+        return self._execute_ship_purchase(best_ship, best_shipyard)
+    
+    def _execute_ship_purchase(self, ship_info: Dict[str, Any], shipyard: Dict[str, Any]) -> bool:
+        """
+        Execute the actual ship purchase.
+        
+        Args:
+            ship_info: Information about the ship to purchase
+            shipyard: Shipyard where the ship is available
+            
+        Returns:
+            bool: True if purchase successful
+        """
+        ship_type = ship_info.get('type')
+        price = ship_info.get('purchasePrice', 0)
+        waypoint_symbol = shipyard['waypoint_symbol']
+        
+        self.logger.info(f"Attempting to purchase {ship_type} for {price:,} credits at {waypoint_symbol}")
+        
+        try:
+            # First, move a ship to the shipyard if needed
+            ship_at_shipyard = self._get_ship_at_waypoint(waypoint_symbol)
+            
+            if not ship_at_shipyard:
+                # Move our closest ship to the shipyard
+                success = self._move_ship_to_waypoint(waypoint_symbol)
+                if not success:
+                    self.logger.error(f"Failed to move ship to shipyard at {waypoint_symbol}")
+                    return False
+                
+                ship_at_shipyard = self._get_ship_at_waypoint(waypoint_symbol)
+            
+            if not ship_at_shipyard:
+                self.logger.error("No ship available at shipyard for purchase")
+                return False
+            
+            # Make the purchase
+            response = self.api_client.purchase_ship(ship_type, waypoint_symbol)
+            
+            if response and 'data' in response:
+                ship_data = response['data'].get('ship', {})
+                agent_data = response['data'].get('agent', {})
+                transaction = response['data'].get('transaction', {})
+                
+                if ship_data:
+                    new_ship = Ship.from_api_response(ship_data)
+                    self.context.ships.append(new_ship)
+                    
+                    self.logger.info(f"✅ Successfully purchased ship {new_ship.symbol}")
+                    self.logger.info(f"   Type: {ship_type}")
+                    self.logger.info(f"   Cargo Capacity: {new_ship.cargo_capacity}")
+                    self.logger.info(f"   Price: {price:,} credits")
+                
+                # Update agent credits
+                if agent_data:
+                    old_credits = self.context.agent_data.credits
+                    self.context.update_agent_data({'data': agent_data})
+                    new_credits = self.context.agent_data.credits
+                    
+                    self.logger.info(f"Credits: {old_credits:,} → {new_credits:,} (-{old_credits - new_credits:,})")
+                
+                return True
+            else:
+                self.logger.error("Invalid response from ship purchase API")
+                return False
+                
+        except Exception as e:
+            self.logger.error(f"Failed to purchase ship {ship_type}: {e}")
+            return False
+    
+    def _get_ship_at_waypoint(self, waypoint_symbol: str) -> Optional[Ship]:
+        """Get a ship that is at the specified waypoint."""
+        for ship in self.context.ships:
+            if ship.nav.waypoint_symbol == waypoint_symbol:
+                return ship
+        return None
+    
+    def _move_ship_to_waypoint(self, waypoint_symbol: str) -> bool:
+        """Move a ship to the specified waypoint."""
+        # Find the best ship to move (closest, with fuel, etc.)
+        best_ship = None
+        
+        for ship in self.context.ships:
+            if ship.nav.is_in_transit:
+                continue  # Skip ships in transit
+            
+            if ship.fuel.current <= 0:
+                continue  # Skip ships without fuel
+            
+            # For now, just pick the first available ship
+            best_ship = ship
+            break
+        
+        if not best_ship:
+            self.logger.warning("No ship available to move to shipyard")
+            return False
+        
+        try:
+            self.logger.info(f"Moving ship {best_ship.symbol} to {waypoint_symbol}")
+            
+            # Make sure ship is in orbit
+            if best_ship.nav.is_docked:
+                self.api_client.orbit_ship(best_ship.symbol)
+            
+            # Navigate to waypoint
+            response = self.api_client.navigate_ship(best_ship.symbol, waypoint_symbol)
+            
+            if response:
+                self.logger.info(f"Ship {best_ship.symbol} navigating to {waypoint_symbol}")
+                # In a real implementation, we might wait for arrival
+                return True
+            
+        except Exception as e:
+            self.logger.error(f"Failed to move ship to waypoint: {e}")
+        
+        return False
+    
+    def _ensure_ships_fueled(self) -> None:
+        """Ensure all ships have adequate fuel."""
+        for ship in self.context.ships:
+            if ship.fuel.needs_refuel and ship.nav.is_docked:
+                try:
+                    self.logger.info(f"Refueling ship {ship.symbol}")
+                    self.api_client.refuel_ship(ship.symbol)
+                except Exception as e:
+                    self.logger.warning(f"Failed to refuel ship {ship.symbol}: {e}")
+    
+    def _refresh_ship_data(self) -> None:
+        """Refresh ship data from the API."""
+        try:
+            response = self.api_client.get_my_ships()
+            ships_data = response.get('data', [])
+            
+            self.context.ships = [
+                Ship.from_api_response(ship_data)
+                for ship_data in ships_data
+            ]
+            
+            total_capacity = self.context.get_total_cargo_capacity()
+            self.logger.info(f"Updated ship data - Total cargo capacity: {total_capacity}")
+            
+        except Exception as e:
+            self.logger.error(f"Failed to refresh ship data: {e}")
+
+
+# Need to add the purchase_ship method to the API client

--- a/states/negotiate_contract.py
+++ b/states/negotiate_contract.py
@@ -1,0 +1,344 @@
+"""
+NEGOTIATE_CONTRACT state implementation.
+
+This state finds and evaluates available contracts, selecting the best one for acceptance.
+"""
+
+from typing import Optional, List
+from models.state_enums import AgentState
+from states.base_state import BaseState
+from models.contract import Contract
+
+
+class NegotiateContractState(BaseState):
+    """
+    State for finding and evaluating available contracts.
+    
+    This state:
+    1. Retrieves available contracts from the API
+    2. Filters contracts based on agent capabilities
+    3. Calculates profitability scores for each contract
+    4. Selects the best contract for acceptance
+    """
+    
+    def execute(self) -> Optional[AgentState]:
+        """
+        Execute the NEGOTIATE_CONTRACT state logic.
+        
+        Returns:
+            AgentState: Next state to transition to (ACCEPT_CONTRACT or ERROR_RECOVERY)
+        """
+        self.log_state_entry()
+        
+        try:
+            # Step 1: Get available contracts
+            available_contracts = self._get_available_contracts()
+            
+            if not available_contracts:
+                self.logger.warning("No available contracts found")
+                # Wait a bit before trying again
+                import time
+                time.sleep(10)
+                return AgentState.NEGOTIATE_CONTRACT
+            
+            # Step 2: Filter contracts by capabilities
+            suitable_contracts = self._filter_contracts_by_capabilities(available_contracts)
+            
+            if not suitable_contracts:
+                self.logger.warning("No suitable contracts found for current capabilities")
+                
+                # Analyze why contracts were filtered out
+                next_action = self._analyze_filtering_reasons(available_contracts)
+                
+                if next_action == AgentState.ACQUIRE_RESOURCES:
+                    self.logger.info("Need to acquire more resources (ships/capacity) to handle available contracts")
+                    next_state = AgentState.ACQUIRE_RESOURCES
+                    self.log_state_exit(next_state)
+                    return next_state
+                else:
+                    # Wait before trying again if it's a temporary issue
+                    import time
+                    time.sleep(30)  # Longer wait for contracts to potentially change
+                    return AgentState.NEGOTIATE_CONTRACT
+            
+            # Step 3: Evaluate and rank contracts
+            best_contract = self._select_best_contract(suitable_contracts)
+            
+            if best_contract:
+                self.context.current_contract = best_contract
+                self.logger.info(f"Selected contract {best_contract.contract_id} for acceptance")
+                self._log_contract_details(best_contract)
+                
+                next_state = AgentState.ACCEPT_CONTRACT
+                self.log_state_exit(next_state)
+                return next_state
+            else:
+                self.logger.warning("No profitable contracts found")
+                # Wait before trying again
+                import time
+                time.sleep(10)
+                return AgentState.NEGOTIATE_CONTRACT
+                
+        except Exception as e:
+            self.logger.error(f"Error in NEGOTIATE_CONTRACT state: {e}")
+            return AgentState.ERROR_RECOVERY
+    
+    def _get_available_contracts(self) -> List[Contract]:
+        """
+        Retrieve available contracts from the API.
+        
+        Returns:
+            List[Contract]: List of available contracts
+        """
+        self.logger.info("Retrieving available contracts...")
+        
+        try:
+            # Get contracts from API
+            response = self.api_client.get_my_contracts()
+            contracts_data = response.get('data', [])
+            
+            # Convert to Contract objects
+            all_contracts = [
+                Contract.from_api_response(contract_data)
+                for contract_data in contracts_data
+            ]
+            
+            # Filter for available (not accepted, not expired) contracts
+            available_contracts = [
+                contract for contract in all_contracts
+                if not contract.accepted and not contract.fulfilled and not contract.is_expired
+            ]
+            
+            self.logger.info(f"Found {len(available_contracts)} available contracts out of {len(all_contracts)} total")
+            
+            return available_contracts
+            
+        except Exception as e:
+            self.logger.error(f"Failed to retrieve contracts: {e}")
+            raise
+    
+    def _filter_contracts_by_capabilities(self, contracts: List[Contract]) -> List[Contract]:
+        """
+        Filter contracts based on agent capabilities.
+        
+        Args:
+            contracts: List of contracts to filter
+            
+        Returns:
+            List[Contract]: Contracts that the agent can potentially fulfill
+        """
+        self.logger.info("Filtering contracts by agent capabilities...")
+        
+        if not self.context.ships:
+            self.logger.warning("No ships available for contract evaluation")
+            return []
+        
+        suitable_contracts = []
+        total_cargo_capacity = self.context.get_total_cargo_capacity()
+        
+        for contract in contracts:
+            # Check if we have enough total cargo capacity
+            total_units_needed = sum(delivery.units_required for delivery in contract.terms.deliveries)
+            
+            if total_units_needed > total_cargo_capacity:
+                self.logger.info(f"Contract {contract.contract_id} requires {total_units_needed} units, "
+                                f"but we only have {total_cargo_capacity} capacity - skipping")
+                continue
+            
+            # Check if we have sufficient credits for potential costs
+            estimated_cost = self._estimate_contract_cost(contract)
+            if not self.context.has_sufficient_credits(estimated_cost):
+                self.logger.info(f"Contract {contract.contract_id} estimated cost {estimated_cost:,} "
+                                f"exceeds available credits - skipping")
+                continue
+            
+            # Check if we can handle deliveries with our fleet (allowing multi-ship deliveries)
+            # For now, we'll be more permissive - if total capacity > total required, we can handle it
+            # A more sophisticated implementation could check if deliveries can be split optimally
+            max_delivery_size = max(
+                (delivery.units_required for delivery in contract.terms.deliveries),
+                default=0
+            )
+            largest_ship_capacity = max((ship.cargo_capacity for ship in self.context.ships), default=0)
+            
+            # Only filter out if even our largest ship can't handle the biggest delivery
+            # AND we don't have enough total capacity (safety check)
+            if max_delivery_size > largest_ship_capacity and total_units_needed > total_cargo_capacity:
+                self.logger.info(f"Contract {contract.contract_id} largest delivery ({max_delivery_size} units) "
+                                f"exceeds largest ship capacity ({largest_ship_capacity}) and total requirement "
+                                f"({total_units_needed}) exceeds total capacity ({total_cargo_capacity}) - skipping")
+                continue
+            elif max_delivery_size > largest_ship_capacity:
+                self.logger.info(f"Contract {contract.contract_id} largest delivery ({max_delivery_size} units) "
+                                f"exceeds largest ship ({largest_ship_capacity}), but may be splittable across fleet - keeping")
+            
+            # Log acceptance reason for debugging
+            self.logger.info(f"Contract {contract.contract_id} passed ship capacity check - "
+                            f"largest delivery: {max_delivery_size}, largest ship: {largest_ship_capacity}, "
+                            f"total required: {total_units_needed}, total capacity: {total_cargo_capacity}")
+            
+            suitable_contracts.append(contract)
+        
+        self.logger.info(f"Found {len(suitable_contracts)} suitable contracts after filtering")
+        return suitable_contracts
+    
+    def _analyze_filtering_reasons(self, contracts: List[Contract]) -> AgentState:
+        """
+        Analyze why contracts were filtered out and determine the best action.
+        
+        Args:
+            contracts: List of contracts that were evaluated
+            
+        Returns:
+            AgentState: Recommended next action
+        """
+        if not contracts:
+            return AgentState.NEGOTIATE_CONTRACT
+        
+        total_cargo_capacity = self.context.get_total_cargo_capacity()
+        capacity_issues = 0
+        credit_issues = 0
+        ship_size_issues = 0
+        
+        for contract in contracts:
+            total_units_needed = sum(delivery.units_required for delivery in contract.terms.deliveries)
+            estimated_cost = self._estimate_contract_cost(contract)
+            max_delivery_size = max(
+                (delivery.units_required for delivery in contract.terms.deliveries),
+                default=0
+            )
+            
+            # Count reasons for filtering
+            if total_units_needed > total_cargo_capacity:
+                capacity_issues += 1
+            
+            if not self.context.has_sufficient_credits(estimated_cost):
+                credit_issues += 1
+            
+            largest_ship_capacity = max((ship.cargo_capacity for ship in self.context.ships), default=0)
+            # Only count as ship size issue if largest delivery exceeds largest ship AND total exceeds total capacity
+            if max_delivery_size > largest_ship_capacity and total_units_needed > total_cargo_capacity:
+                ship_size_issues += 1
+        
+        self.logger.info(f"Contract filtering analysis: "
+                        f"capacity issues: {capacity_issues}/{len(contracts)}, "
+                        f"credit issues: {credit_issues}/{len(contracts)}, "
+                        f"ship size issues: {ship_size_issues}/{len(contracts)}")
+        
+        # Prioritize solutions based on most common issues
+        if capacity_issues > 0 or ship_size_issues > 0:
+            # Need more or bigger ships
+            if self.context.agent_data and self.context.agent_data.credits > 50000:  # Rough ship cost
+                
+                # Check if we recently failed to acquire resources
+                last_attempt = self.context.strategy_config.get('last_acquire_attempt', 0)
+                acquire_failed = self.context.strategy_config.get('acquire_failed', False)
+                import time
+                
+                # Only try to acquire resources if we haven't recently failed
+                if not acquire_failed or (time.time() - last_attempt) > 3600:  # 1 hour cooldown
+                    return AgentState.ACQUIRE_RESOURCES
+                else:
+                    self.logger.info("Recently failed to acquire resources, will wait for suitable contracts")
+        
+        # If it's mainly credit issues, or we don't have enough credits for ships
+        # Just wait for different contracts or more credits from other sources
+        return AgentState.NEGOTIATE_CONTRACT
+    
+    def _estimate_contract_cost(self, contract: Contract) -> int:
+        """
+        Estimate the cost to fulfill a contract.
+        
+        Args:
+            contract: Contract to estimate costs for
+            
+        Returns:
+            int: Estimated cost in credits
+        """
+        # Simple cost estimation - in a real implementation, this would be more sophisticated
+        # For now, estimate based on goods volume and potential fuel costs
+        
+        total_units = sum(delivery.units_required for delivery in contract.terms.deliveries)
+        
+        # Rough estimates:
+        # - 100 credits per unit for goods (very rough average)
+        # - 10% of payment for fuel and other costs
+        estimated_goods_cost = total_units * 100
+        estimated_fuel_cost = int(contract.terms.total_payment * 0.1)
+        
+        total_cost = estimated_goods_cost + estimated_fuel_cost
+        
+        self.logger.info(f"Contract {contract.contract_id} estimated cost: {total_cost:,} "
+                         f"(goods: {estimated_goods_cost:,}, fuel: {estimated_fuel_cost:,})")
+        
+        return total_cost
+    
+    def _select_best_contract(self, contracts: List[Contract]) -> Optional[Contract]:
+        """
+        Select the best contract from suitable options.
+        
+        Args:
+            contracts: List of suitable contracts
+            
+        Returns:
+            Optional[Contract]: Best contract, or None if none are profitable
+        """
+        self.logger.info(f"Evaluating {len(contracts)} contracts for profitability...")
+        
+        if not contracts:
+            return None
+        
+        cargo_capacity = self.context.get_total_cargo_capacity()
+        contract_scores = []
+        
+        for contract in contracts:
+            estimated_cost = self._estimate_contract_cost(contract)
+            score = contract.calculate_profitability_score(cargo_capacity, estimated_cost)
+            
+            contract_scores.append((contract, score, estimated_cost))
+            
+            profit = contract.terms.total_payment - estimated_cost
+            profit_margin = (profit / contract.terms.total_payment) * 100 if contract.terms.total_payment > 0 else 0
+            
+            self.logger.info(f"Contract {contract.contract_id}: "
+                           f"Payment: {contract.terms.total_payment:,}, "
+                           f"Est. Cost: {estimated_cost:,}, "
+                           f"Profit: {profit:,} ({profit_margin:.1f}%), "
+                           f"Score: {score:.2f}")
+        
+        # Sort by score (highest first)
+        contract_scores.sort(key=lambda x: x[1], reverse=True)
+        
+        # Select the best contract if it has a positive score
+        if contract_scores and contract_scores[0][1] > 0:
+            best_contract, best_score, best_cost = contract_scores[0]
+            
+            profit = best_contract.terms.total_payment - best_cost
+            self.logger.info(f"Selected best contract {best_contract.contract_id} "
+                           f"with score {best_score:.2f} and expected profit {profit:,}")
+            
+            return best_contract
+        else:
+            self.logger.warning("No contracts with positive profitability scores found")
+            return None
+    
+    def _log_contract_details(self, contract: Contract) -> None:
+        """Log details of the selected contract."""
+        self.logger.info(f"Contract {contract.contract_id} details:")
+        self.logger.info(f"  Type: {contract.contract_type.value}")
+        self.logger.info(f"  Faction: {contract.faction_symbol}")
+        self.logger.info(f"  Payment: {contract.terms.total_payment:,} credits")
+        self.logger.info(f"    - On Accept: {contract.terms.payment_on_accepted:,}")
+        self.logger.info(f"    - On Fulfill: {contract.terms.payment_on_fulfilled:,}")
+        self.logger.info(f"  Deadline: {contract.terms.deadline}")
+        
+        for i, delivery in enumerate(contract.terms.deliveries, 1):
+            self.logger.info(f"  Delivery {i}: {delivery.units_required} {delivery.trade_symbol} "
+                           f"to {delivery.destination_symbol}")
+        
+        # Calculate time remaining
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc)
+        time_remaining = contract.terms.deadline - now
+        hours_remaining = time_remaining.total_seconds() / 3600
+        self.logger.info(f"  Time remaining: {hours_remaining:.1f} hours")


### PR DESCRIPTION
- Fix cargo capacity calculation to use ship.cargo.capacity instead of rough estimates
- Filter out ships with zero cargo capacity (surveyors, mining drones, etc.)
- Add detailed logging of available ships in shipyards with type, price, and cargo capacity
- Handle empty shipyards gracefully with appropriate wait times
- Improve multi-ship contract filtering logic to be less restrictive

🤖 Generated with [Claude Code](https://claude.ai/code)